### PR TITLE
Fixes in readme due to changes in Anaconda distro

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ StarKit
 Installation
 ************
 
-We recommend you use `Anaconda <http://continuum.io/downloads>`_ to install
+We recommend you use `Anaconda <https://www.anaconda.com/distribution/>`_ to install
 the necessary requirements for Starkit to work.
 
 Once you have anaconda installed please make a new environment with the prerequisites
@@ -18,7 +18,7 @@ for starkit in the following way. This will create an environment called `starki
     # you can change the -n argument
     
     conda env create --file starkit_env27.yml -n starkit
-    source activate starkit
+    conda activate starkit
 
 
 Then you can install any other packages you like with::

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,9 @@ for starkit in the following way. This will create an environment called `starki
     # you can change the -n argument
     
     conda env create --file starkit_env27.yml -n starkit
-    conda activate starkit
+    source activate starkit
+    
+    # OR you may need to use: conda activate starkit
 
 
 Then you can install any other packages you like with::


### PR DESCRIPTION
1. Fixed the link to download Anaconda which was dead as [Continuum Analytics has officially became Anaconda](https://www.anaconda.com/continuum-analytics-officially-becomes-anaconda/) so all their links are under domain `anaconda.com` not under `continuum.io`.
2. Changed the `source activate` to `conda activate` - as this is the preferred way since release of v4.4.0 (2017-12-20) as mentioned in [this section of release note](https://conda.io/projects/conda/en/latest/release-notes.html#id97). 
And since [you have already mentioned](https://github.com/starkit/starkit/pull/29#issuecomment-463066338) that this requires a separate activation by `conda.sh` file. But in my experience for fresh installs (>=v4.4.0), this is automatically activated while installation from the downloaded .sh file (in MacOS & Linux) and .exe file (in Windows), and the [official docs](https://conda.io/projects/conda/en/latest/user-guide/install/index.html) also doesn't mention to do extra setup for this.