### PR TITLE
Downgrade setuptools to 36.2.0

### DIFF
--- a/starkit_env27.yml
+++ b/starkit_env27.yml
@@ -28,6 +28,7 @@ dependencies:
 - pytest-cov=2.2.1
 
 - pip:
+  - setuptools==36.2.0
   - sphinx_bootstrap_theme
   - sphinxcontrib-bibtex
   - sphinxcontrib-tikz


### PR DESCRIPTION
Downgraded setuptools so that starkit gets installed properly.