### PR TITLE
Fixed error in installing starkit on env2.7 since its upgrade to env3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ except ImportError:
 conf = ConfigParser()
 conf.read(['setup.cfg'])
 metadata = dict(conf.items('metadata'))
+metadata={str(k): str(v) for k, v in metadata.items()} #Making sure parsed data is in string not unicode
 
 PACKAGENAME = metadata.get('package_name', 'packagename')
 DESCRIPTION = metadata.get('description', 'Astropy affiliated package')


### PR DESCRIPTION
While installing `starkit`, I received following error:
```bash
$ python setup.py install
Traceback (most recent call last):
  File "setup.py", line 61, in <module>
    cmdclassd = register_commands(PACKAGENAME, VERSION, RELEASE)
  File "/home/jpolygon/starkit-wrkspc/inst-err-wsp/starkit/astropy_helpers/astropy_helpers/setup_helpers.py", line 162, in register_commands
    'test': generate_test_command(package),
  File "/home/jpolygon/starkit-wrkspc/inst-err-wsp/starkit/astropy_helpers/astropy_helpers/setup_helpers.py", line 318, in generate_test_command
    {'package_name': package_name})
TypeError: type() argument 1 must be string, not unicode
```
Same error is causing [Travis CI build fail](https://travis-ci.com/starkit/starkit/jobs/184349425) since [PR#32](https://github.com/starkit/starkit/pull/32) was merged until Travis was running it on env2.7.

The cause of problem is that `ConfigParser()` parses data from `setup.cfg` in unicode for python2.7 (quite similar to [this](https://github.com/myint/language-check/pull/37#issue-112064510)). This is not accepted by `generate_test_command` as shown in traceback above, so it is necessary to convert it into string.