### PR TITLE
Make starkit compatible for both python 3 & 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ matrix:
         # Generate docs
         - python: 2.7
           env: SETUP_CMD='build_docs'
+          
+        # Do a coverage test in Python 3.
+        - python: 3.6
+          env: SETUP_CMD='test --coverage'
 
 before_install:
 
@@ -37,7 +41,8 @@ before_install:
 install:
 
     # CONDA
-    - conda env create -n starkit --file ./starkit_env3.yml
+    - if [[ $TRAVIS_PYTHON_VERSION == 2.7 ]]; then conda env create -n starkit --file ./starkit_env27.yml;
+      elif [[ $TRAVIS_PYTHON_VERSION == 3.6 ]]; then conda env create -n starkit --file ./starkit_env3.yml; fi
     - source activate starkit
 
     # OPTIONAL DEPENDENCIES

--- a/starkit/gridkit/io/phoenix/base.py
+++ b/starkit/gridkit/io/phoenix/base.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 from glob import glob
 from astropy.io import fits
 import pandas as pd
@@ -44,7 +45,7 @@ def make_raw_index():
     """
     all_fnames = glob('PHOENIX-ACES-AGSS-COND-2011/Z*/*.fits')
     phoenix_index = pd.DataFrame(index=np.arange(len(all_fnames)), columns=['teff', 'logg', 'mh', 'alpha', 'filename'])
-    print "Reading Phoenix grid..."
+    print("Reading Phoenix grid...")
     progressbar = ProgressBar(max_value=len(all_fnames))
     for i, fname in progressbar(enumerate(all_fnames)):
         spec_header = fits.getheader(fname)


### PR DESCRIPTION
This PR solves following:
1. Syntax of print statement is of python 2.7 which gives [error](https://github.com/starkit/starkit/pull/54#issuecomment-482820255) when using starkit in python3 env -> fixed it using print statement from `__future__` module.
2. Travis CI uses only `starkit_env3.yml` hence run only for python3 -> added conditional selection of environment file based on python version being used.
3. Travis CI does coverage test only for python2.7 but should also do it for python 3.6 -> added coverage test for python 3.6.