### PR TITLE
Update astropy_helpers submodule (same as in wsynphot)

### DIFF
--- a/deploy_docs.sh
+++ b/deploy_docs.sh
@@ -7,4 +7,4 @@ source activate python36
 
 conda install -c conda-forge doctr --yes
 
-doctr deploy . --built-docs build/sphinx/html 
+doctr deploy . --built-docs docs/_build/html 


### PR DESCRIPTION
The astropy_helpers submodule is outdated due to which built docs are stored in `build/sphinx/html` dir instead of the common `docs` dir: `docs/build/html` i.e. fixed in v2.0.10 (same which we're successfully using in wsynphot). Besides, in this new version, there are some other Sphinx compatibility fixes as well. This will make sure that our upcoming code doesn't confuse in Sphinx docs path and use the one which is standard i.e. found in almost every documentation on web.

I've tested & verified, using this there's no problem in docs building & even they are received in desired directory.