### PR TITLE
Disable use_2to3 flag to make `setup.py develop` work fine in python3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -119,7 +119,7 @@ setup(name=PACKAGENAME,
       long_description=LONG_DESCRIPTION,
       cmdclass=cmdclassd,
       zip_safe=False,
-      use_2to3=True,
+      use_2to3=False,
       entry_points=entry_points,
       **package_info
 )


### PR DESCRIPTION
This PR fixes same problem as in https://github.com/starkit/wsynphot/pull/38