### PR TITLE
Integrate the list of available test grids at Zenodo in docs

### DIFF
--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -2,6 +2,7 @@
 Getting Started
 ***************
 
+.. _working-with-grid:
 
 Working with the grid
 ^^^^^^^^^^^^^^^^^^^^^

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,11 +18,7 @@ Input/Output
 .. toctree::
     :maxdepth: 5
 
-    io/reading_phoenix.ipynb
-    io/reading_bosz.ipynb
-    io/reading_moehler_telluric.ipynb
-    io/gridkit_fileformat
-
+    io/index.rst
 
 --------
 Examples

--- a/docs/io/available_grids.rst
+++ b/docs/io/available_grids.rst
@@ -1,0 +1,64 @@
+=====================
+Available Test Grids
+=====================
+
+If you don't prefer to create a grid on your own, you can use any of the following test grids (HDF5 files) to start :ref:`working with grids <working-with-grid>`. Please make sure to cite these grids if you use them (citing information can be found at hyperlinked Zenodo URL of the grid file).
+
+.. list-table::
+   :header-rows: 1
+
+   * - Test Grid File
+     - Grid Name
+     - Resolution
+     - Wavelength (Ang) low
+     - Wavelength (Ang) high
+     - Teff low
+     - Teff high
+     - log g low
+     - log g high
+     - [M/H] low
+     - [M/H] high
+     - [alpha/Fe] low
+     - [alpha/Fe] high
+
+   * - `phoenix_t2000_6000_w20000_24000_R25000 <https://zenodo.org/record/2578285>`_
+     - Phoenix
+     - 25000
+     - 20000
+     - 24000
+     - 2000
+     - 6000
+     - 0.0
+     - 5.0
+     - -2.0
+     - 1.0
+     - -1.0
+     - 1.0
+
+   * - `phoenix_t4000_10000_w3000_9000_r3000 <https://zenodo.org/record/2557923>`_
+     - Phoenix
+     - 3000
+     - 3000
+     - 9000
+     - 4000
+     - 10000
+     - 3.0
+     - 5.0
+     - -1.0
+     - 0.0
+     - \-
+     - \-
+
+   * - `phoenix_t2000_6000_w21500_22200_R40000_o35 <https://zenodo.org/record/2563357>`_
+     - Phoenix
+     - 40000
+     - 21500
+     - 22200
+     - 2000
+     - 6000
+     - 0.0
+     - 4.5
+     - -2.0
+     - 1.0
+     - -0.4
+     - 1.0

--- a/docs/io/index.rst
+++ b/docs/io/index.rst
@@ -7,7 +7,11 @@ Input/Output Documentation
 
 
 .. toctree::
+   :maxdepth: 2
 
-    read_phoenix
-    gridkit_fileformat
-    phoenix
+   reading_phoenix
+   reading_bosz
+   reading_moehler_telluric
+   phoenix
+   gridkit_fileformat
+   available_grids


### PR DESCRIPTION
- Added a rst file to enlist all test grids (currently 3) available at Zenodo with their major properties, along with a few lines on why & how to use it
- The i/o doc files are not properly included in TOC (some have typo in name, some were listed directly even when index exists for subdir) - fixed all those problems & made TOC clearer