### PR TITLE
Update gitignore to ignore other necessary files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,13 +1,14 @@
 # Compiled files
-*.py[co]
+*.py[cod]
 *.a
 *.o
 *.so
 __pycache__
 
-# Ignore .c files by default to avoid including generated code. If you want to
+# Ignore C/C++ files by default to avoid including generated code. If you want to
 # add a non-generated .c extension, use `git add -f filename.c`.
 *.c
+*.cpp
 
 # Other generated files
 */version.py
@@ -15,6 +16,7 @@ __pycache__
 htmlcov
 .coverage
 MANIFEST
+.ipynb_checkpoints
 
 # Sphinx
 docs/api
@@ -27,6 +29,10 @@ docs/_build
 
 # Pycharm editor project files
 .idea
+
+# Floobits project files
+.floo
+.flooignore
 
 # Packages/installer info
 *.egg
@@ -43,8 +49,13 @@ develop-eggs
 distribute-*.tar.gz
 
 # Other
-.*.swp
+.cache
+.tox
+.*.sw[op]
 *~
+.project
+.pydevproject
+.settings
 
 # Mac OSX
 .DS_Store


### PR DESCRIPTION
While working with notebooks I observed git was tracking `.ipynb_checkpoints` files which was not the case with wsynphot. So I compared `gitignore` files of both and made that of starkit similar to wsynphot - adding several necessary file types to ignore.