### PR TITLE
Fix failure in deploying starkit docs

### DIFF
--- a/azure_pipelines/deploy_docs.sh
+++ b/azure_pipelines/deploy_docs.sh
@@ -49,5 +49,7 @@ fi
 
 # Otherwise, commit and push
 git commit -m "Deploy to GitHub Pages: ${SHA}"
-git push $SSH_REPO $TARGET_BRANCH
-cd ..
+# Don't push if it's a PR build because it doesn't have access rights to do so
+if [ $BUILD_REASON != "PullRequest" ]; then
+  git push $SSH_REPO $TARGET_BRANCH
+fi

--- a/azure_pipelines/deploy_docs.sh
+++ b/azure_pipelines/deploy_docs.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e   # Exit with nonzero exit code if anything fails
 
 # Build the documentation from the SOURCE_BRANCH
 # and push it to TARGET_BRANCH.


### PR DESCRIPTION
Docs are building correctly but are failing to be deployed since #68 because it accidentally pushed the older version of astropy_helpers submodule. Also added `set -e` in deployment script to make the build fail in such cases.