### PR TITLE
Don't update conda for now

### DIFF
--- a/azure_pipelines/docs_deployment_pipeline.yml
+++ b/azure_pipelines/docs_deployment_pipeline.yml
@@ -34,7 +34,7 @@ steps:
 
   - bash: |
       sudo chown -R $USER $CONDA
-      conda update -y conda
+    # conda update -y conda
     displayName: Update conda and activate it
 
   # Build & deploy docs from python3 environment. Hence use starkit_env3.yml

--- a/azure_pipelines/testing_pipeline.yml
+++ b/azure_pipelines/testing_pipeline.yml
@@ -11,7 +11,7 @@ steps:
 
   - bash: |
       sudo chown -R $USER $CONDA
-      conda update -y conda
+    # conda update -y conda
     displayName: Update conda and activate it
 
   - bash: |


### PR DESCRIPTION
Following error occurs at both pipelines when `conda update -y conda` is executed.
```
RemoveError: 'setuptools' is a dependency of conda and cannot be removed from
conda's operating environment.
```

Commenting it for now, and default version of conda at VM is 4.10 i.e. pretty close to v4.12 - the latest version. So there shouldn't be any problems.