### PR TITLE
Use pip to install astropy v1.1.2

### DIFF
--- a/starkit_env3.yml
+++ b/starkit_env3.yml
@@ -7,10 +7,11 @@ dependencies:
 - python=3.6
 - numpy=1
 - h5py=2.9
+- astropy=1.3
 - tqdm=4
 - scipy=1.2
 - pandas=0.24
-- pytables=3.4
+- pytables=3
 
 # Analysis requirements
 - jupyter=1
@@ -37,4 +38,3 @@ dependencies:
 
 - pip:
   - corner
-  - astropy==1.1.2

--- a/starkit_env3.yml
+++ b/starkit_env3.yml
@@ -7,7 +7,6 @@ dependencies:
 - python=3.6
 - numpy=1
 - h5py=2.9
-- astropy=1.1.2
 - tqdm=4
 - scipy=1.2
 - pandas=0.24
@@ -38,4 +37,4 @@ dependencies:
 
 - pip:
   - corner
-  
+  - astropy==1.1.2


### PR DESCRIPTION
The pipelines are failing with package not found error since merge of #70, because conda-forge doesn't have astropy version earlier than v1.3:
![image](https://user-images.githubusercontent.com/36361463/68385550-0cc68580-0180-11ea-8a18-506f8319549e.png)

But PyPI has it, so pip can fetch astropy v1.1.2